### PR TITLE
Fix versions of GD32 platform and SPL package

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,9 +21,9 @@ src_dir     = Src
 
 [env]
 ; use new GD32 platform and the bleeding-edge SPL package for it
-platform = https://github.com/CommunityGD32Cores/platform-gd32.git
+platform = https://github.com/CommunityGD32Cores/platform-gd32.git#e712045bdba54790ed2e07c47a421345340efb31
 platform_packages = 
-    framework-spl-gd32@https://github.com/CommunityGD32Cores/gd32-pio-spl-package.git
+    framework-spl-gd32@https://github.com/CommunityGD32Cores/gd32-pio-spl-package.git#67a6fe90b20e00b11a9a52f55d318b7d15eeed84
 
 ;================================================================
 


### PR DESCRIPTION
Restores successful compilation for the VARIANT_DEBUG environment which in the current version overflows by 44 bytes for some reason.

```
RAM:   [=         ]  14.9% (used 612 bytes from 4096 bytes)
Flash: [==========]  98.8% (used 32364 bytes from 32768 bytes)
Building .pio\build\VARIANT_DEBUG\firmware.bin
====================[SUCCESS] Took 2.53 seconds ====================
```

This patch has the disadvantage that further developments in the GD32 platform are not taken into this project -- the version is frozen now, but also stable in regards to compilation.

Fixes #18.