### PR TITLE
Add i2c_interrupt_enable calls to enable interrupts

### DIFF
--- a/Src/setup.c
+++ b/Src/setup.c
@@ -314,6 +314,10 @@ void i2c_config(void) {
     i2c_enable(MPU_I2C);
     /* enable acknowledge */
     i2c_ack_config(MPU_I2C, I2C_ACK_ENABLE);
+
+    i2c_interrupt_enable(MPU_I2C, I2C_INT_ERR);
+    i2c_interrupt_enable(MPU_I2C, I2C_INT_EV);
+    i2c_interrupt_enable(MPU_I2C, I2C_INT_BUF);
     
     #ifdef AUX45_USE_I2C
         /* I2C clock configure */


### PR DESCRIPTION
** NOT TESTED ON GD32F130C6 **

I [ported this project to a split board](https://github.com/hoverboardhavoc/hoverboard-gen2.1-hack-GD-imu). The board uses a GD32F130C8. I spent a lot of time trying to figure out why `I2C0_EV_IRQHandler` and `I2C0_ER_IRQHandler` were never called. The problem was that the i2c interrupts were never enabled.

```
    i2c_interrupt_enable(MPU_I2C, I2C_INT_ERR);
    i2c_interrupt_enable(MPU_I2C, I2C_INT_EV);
    i2c_interrupt_enable(MPU_I2C, I2C_INT_BUF);
```

I'm not sure why this project works on the GD32F130C6. Maybe the supporting libraries are subtly different or we're using different versions?

If this change does not break the GD32F130C6, I'd like you to merge to prevent other people wasting their time when trying to port the project


Thanks
